### PR TITLE
Allow external parameter type resolution

### DIFF
--- a/EasyCommands/EasyCommands/Commands/CommandDelegate.cs
+++ b/EasyCommands/EasyCommands/Commands/CommandDelegate.cs
@@ -18,6 +18,17 @@ namespace EasyCommands.Commands
         protected Context<TSender> Context;
         protected Dictionary<Type, CustomAttribute> customAttributes = new Dictionary<Type, CustomAttribute>();
 
+        public delegate object ResolveTypeHandler(Type type);
+        /// <summary>
+        /// Allows external type resolution
+        /// </summary>
+        public event ResolveTypeHandler OnResolveType;
+
+        internal object ResolveType(Type type)
+        {
+            return OnResolveType?.Invoke(type);
+        }
+
         public abstract string SyntaxDocumentation(TSender sender);
 
         public CommandDelegate(Context<TSender> context, string mainName, string[] allNames)

--- a/EasyCommands/EasyCommands/Commands/CommandRepository.cs
+++ b/EasyCommands/EasyCommands/Commands/CommandRepository.cs
@@ -50,5 +50,12 @@ namespace EasyCommands.Commands
         public abstract Task Invoke(TSender sender, string command);
 
         protected abstract void AddCommand(CommandDelegate<TSender> command, string[] names);
+
+        /// <summary>
+        /// Allows external type resolutions
+        /// </summary>
+        /// <param name="type">Type requested</param>
+        /// <returns>True when the type is supported by the external system, false otherwise</returns>
+        public virtual bool CanResolveType(Type type) => false;
     }
 }


### PR DESCRIPTION
This allows for TShock to integrate it's service provider to resolve services into command parameters. 
Things like CommandArgs with a Silent property can then be [registered and requested in scope](https://github.com/Pryaxis/TShock/blob/otapi3/TShockCommands/EasyCommandsRepository.cs#L129) of the command and used by the command callback as a parameter.

Hopefully I haven't butchered this...